### PR TITLE
fix: check /sys/modules for fuse directory rather than /proc/modules

### DIFF
--- a/copyfs-mount
+++ b/copyfs-mount
@@ -23,8 +23,8 @@ then
 fi
 
 # Check fuse module
-if ! grep fuse /proc/modules > /dev/null; then
-    if [ $UID = 0 ]; then
+if ! ls /sys/modules | grep fuse > /dev/null; then
+    if [ $UID == 0 ]; then
 	modprobe fuse > /dev/null || {
 	    echo "Could not load fuse kernel module !" 1>&2
 	    exit 1


### PR DESCRIPTION
…since we miss it when it's built into the kernel (also make == consitent with check below)