### PR TITLE
Make it runnable on debian bullseye

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 *.exe
 *.out
 *.app
+
+Makefile
+config.log
+config.status
+copyfs-daemon

--- a/ea.c
+++ b/ea.c
@@ -8,7 +8,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/interface.c
+++ b/interface.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <stdlib.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <sys/time.h>
 #include <time.h>
 


### PR DESCRIPTION
Header <attr/xattr.h> was moved to <sys/xattr.h>, so it was not found when building on latest debian.

